### PR TITLE
Allow cache to hold separate messages for different model configs

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,14 +7,15 @@ import (
 )
 
 type ModelResponseCache interface {
-	GetCachedResponse([]Message) (bool, []Message, Message, error)
-	SetCachedResponse(inputs []Message, aux []Message, out Message) error
+	GetCachedResponse(salt string, inputs []Message) (bool, []Message, Message, error)
+	SetCachedResponse(salt string, inputs []Message, aux []Message, out Message) error
 }
 
-func HashMessages(msgs []Message) string {
+func HashMessages(salt string, inputs []Message) string {
 	s := &strings.Builder{}
+	s.WriteString(salt)
 	s.WriteString("Messages")
-	for _, msg := range msgs {
+	for _, msg := range inputs {
 		s.WriteString(msg.Role.String())
 		s.WriteString(msg.Content)
 		for _, img := range msg.Images {

--- a/cache_memory.go
+++ b/cache_memory.go
@@ -18,8 +18,8 @@ type inMemoryCache struct {
 }
 
 // GetCachedResponse implements ModelResponseCache.
-func (i *inMemoryCache) GetCachedResponse(msgs []Message) (bool, []Message, Message, error) {
-	msgsHash := HashMessages(msgs)
+func (i *inMemoryCache) GetCachedResponse(salt string, msgs []Message) (bool, []Message, Message, error) {
+	msgsHash := HashMessages(salt, msgs)
 	if cp, ok := i.resps[msgsHash]; ok {
 		return true, cp.aux, cp.final, nil
 	}
@@ -27,8 +27,8 @@ func (i *inMemoryCache) GetCachedResponse(msgs []Message) (bool, []Message, Mess
 }
 
 // SetCachedResponse implements ModelResponseCache.
-func (i *inMemoryCache) SetCachedResponse(inputs []Message, aux []Message, out Message) error {
-	msgsHash := HashMessages(inputs)
+func (i *inMemoryCache) SetCachedResponse(salt string, inputs []Message, aux []Message, out Message) error {
+	msgsHash := HashMessages(salt, inputs)
 	i.resps[msgsHash] = memoryCachePacket{
 		aux:   aux,
 		final: out,

--- a/cache_sql.go
+++ b/cache_sql.go
@@ -26,8 +26,8 @@ type sqlModelCachePayload struct {
 	Aux []Message
 }
 
-func (cache *sqlCache) GetCachedResponse(msgs []Message) (bool, []Message, Message, error) {
-	h := HashMessages(msgs)
+func (cache *sqlCache) GetCachedResponse(salt string, msgs []Message) (bool, []Message, Message, error) {
+	h := HashMessages(salt, msgs)
 	row := cache.db.QueryRow(`SELECT resp FROM model_cache WHERE hash=?;`, h)
 	blob := []byte{}
 	err := row.Scan(&blob)
@@ -47,8 +47,8 @@ func (cache *sqlCache) GetCachedResponse(msgs []Message) (bool, []Message, Messa
 	return true, outputs[:len(outputs)-1], outputs[len(outputs)-1], nil
 }
 
-func (cache *sqlCache) SetCachedResponse(inputs []Message, aux []Message, out Message) error {
-	h := HashMessages(inputs)
+func (cache *sqlCache) SetCachedResponse(salt string, inputs []Message, aux []Message, out Message) error {
+	h := HashMessages(salt, inputs)
 	blob := bytes.NewBuffer(nil)
 	err := gob.NewEncoder(blob).Encode(append(aux, out))
 	if err != nil {

--- a/model.go
+++ b/model.go
@@ -92,6 +92,7 @@ type WithSystemAs struct {
 	X                Role
 	TransformContent func(string) string
 }
+type WithSalt struct{ X string }
 
 type WithReasoningAs struct {
 	X                Role

--- a/model_cached.go
+++ b/model_cached.go
@@ -2,7 +2,7 @@ package jpf
 
 // NewCachedModel wraps a Model with response caching functionality.
 // It stores responses in the provided ModelResponseCache implementation,
-// returning cached results for identical input messages to avoid redundant model calls.
+// returning cached results for identical input messages and salts to avoid redundant model calls.
 func NewCachedModel(model Model, cache ModelResponseCache, opts ...CachedModelOpt) Model {
 	m := &cachedModel{
 		model: model,

--- a/model_cached.go
+++ b/model_cached.go
@@ -3,21 +3,32 @@ package jpf
 // NewCachedModel wraps a Model with response caching functionality.
 // It stores responses in the provided ModelResponseCache implementation,
 // returning cached results for identical input messages to avoid redundant model calls.
-func NewCachedModel(model Model, cache ModelResponseCache) Model {
-	return &cachedModel{
+func NewCachedModel(model Model, cache ModelResponseCache, opts ...CachedModelOpt) Model {
+	m := &cachedModel{
 		model: model,
 		cache: cache,
 	}
+	for _, o := range opts {
+		o.applyCachedModel(m)
+	}
+	return m
 }
+
+type CachedModelOpt interface {
+	applyCachedModel(*cachedModel)
+}
+
+func (o WithSalt) applyCachedModel(m *cachedModel) { m.salt = o.X }
 
 type cachedModel struct {
 	model Model
 	cache ModelResponseCache
+	salt  string
 }
 
 // Respond implements Model.
 func (c *cachedModel) Respond(msgs []Message) (ModelResponse, error) {
-	ok, aux, final, err := c.cache.GetCachedResponse(msgs)
+	ok, aux, final, err := c.cache.GetCachedResponse(c.salt, msgs)
 	if err != nil {
 		return ModelResponse{}, wrap(err, "failed to query cache")
 	}
@@ -31,7 +42,7 @@ func (c *cachedModel) Respond(msgs []Message) (ModelResponse, error) {
 	if err != nil {
 		return resp.OnlyUsage(), err
 	}
-	err = c.cache.SetCachedResponse(msgs, resp.AuxilliaryMessages, resp.PrimaryMessage)
+	err = c.cache.SetCachedResponse(c.salt, msgs, resp.AuxilliaryMessages, resp.PrimaryMessage)
 	if err != nil {
 		return resp.OnlyUsage(), wrap(err, "failed to set cache")
 	}


### PR DESCRIPTION
Fixes #24 

- I think that  we should allow the user to specify which models share cache and which do not
- I will add a "salt" to the cached model (optional parameter), which will change the hash of the caches
- When mot specifying, by default your model will share cache will all other models that have not specified
- The idea is that your builder should decide this salt deterministically based on the things you care about most
    - Might include model name, url
    - Maybe your model is named two different things on two urls but you want them to share the same cache.
    - Maybe you want to cache based on temperature.
    - Maybe you want all non-zero temperatures to share the same cache
 - As you can see there are lots of cases, and I don't want to force the user to have to use some specific rules