### PR TITLE
Fix OpenAI model reasoning role not being transformed

### DIFF
--- a/model_openai.go
+++ b/model_openai.go
@@ -113,7 +113,7 @@ func (m *openAIModel) messagesToOpenAI(msgs []Message) (any, error) {
 			}
 			content = cont
 		}
-		oaiRole, err := roleToOpenAI(msg.Role)
+		oaiRole, err := roleToOpenAI(role)
 		if err != nil {
 			return nil, err
 		}

--- a/model_test.go
+++ b/model_test.go
@@ -13,7 +13,7 @@ func TestConstructOtherModels(t *testing.T) {
 	model = NewConcurrentLimitedModel(model, NewOneConcurrentLimiter())
 	model = NewFakeReasoningModel(model, model, WithReasoningPrompt{X: "Reason please"})
 	model = NewLoggingModel(model, NewJsonModelLogger(os.Stdout))
-	model = NewRetryModel(model, 10, WithDelay{X: time.Second})
+	NewRetryModel(model, 10, WithDelay{X: time.Second})
 }
 
 func TestCachedModel(t *testing.T) {


### PR DESCRIPTION
- Mistakenly not using remapped role in openai model