### PR TITLE
Add model timeouts

### DIFF
--- a/model.go
+++ b/model.go
@@ -72,6 +72,7 @@ const (
 	HighVerbosity
 )
 
+type WithTimeout struct{ X time.Duration }
 type WithMessagePrefix struct{ X string }
 type WithDelay struct{ X time.Duration }
 type WithTemperature struct{ X float64 }


### PR DESCRIPTION
Fixes #28 
- Add timeouts to gemini and openAI models
- I have chosen to do this at the base model level instead as a composition as it lets me cancel the actual requests rather than leave them hanging
- Maybe in the future we can consider adding support for context throughout all models