### PR TITLE
Add Rate limited model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/JoshPattman/jpf
 
-go 1.23.1
+go 1.24.0
+
+toolchain go1.24.9
+
+require golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.23.1
+go 1.24.0
+
+toolchain go1.24.9
 
 use (
 	.

--- a/model_ratelimited.go
+++ b/model_ratelimited.go
@@ -1,0 +1,30 @@
+package jpf
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/time/rate"
+)
+
+var _ Model = &rateLimitedModel{}
+
+func NewRateLimitedModel(model Model, limiter *rate.Limiter) Model {
+	return &rateLimitedModel{
+		limiter: limiter,
+		model:   model,
+	}
+}
+
+type rateLimitedModel struct {
+	limiter *rate.Limiter
+	model   Model
+}
+
+func (r *rateLimitedModel) Respond(ctx context.Context, msgs []Message) (ModelResponse, error) {
+	err := r.limiter.Wait(ctx)
+	if err != nil {
+		return ModelResponse{}, errors.Join(errors.New("failed to wait for rate limiter"), err)
+	}
+	return r.model.Respond(ctx, msgs)
+}


### PR DESCRIPTION
Fixes  #34 
- Use new `golang.org/x/time/rate`  package to create a rate limited model model
- Maybe in the future this can replace the ConcurrentLimitedModel
- Disadvantages: Need very latest go, is not stdlib (yet)