### PR TITLE
Stream callback on calling model, not on init

### DIFF
--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -5,42 +5,47 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/JoshPattman/jpf/encoders"
+	"github.com/JoshPattman/jpf"
 	"github.com/JoshPattman/jpf/models"
-	"github.com/JoshPattman/jpf/parsers"
-	"github.com/JoshPattman/jpf/pipelines"
 )
 
 func main() {
-	// Here we are defining a callback that happens on each stream.
-	// This is intended to be used as a supplement to the final response, and should not really be used instead.
-	// For example, if the cache is hit, there will be no stream, so the final response is still needed.
-	onStream := func(text string) {
-		fmt.Print(text)
-	}
 	// Create the model.
 	// We can still use normal encoders, decoders, and retry logic (do be aware that retries will call the onBegin callback again).
-	model := models.NewRemote(models.OpenAI, "gpt-4.1", os.Getenv("OPENAI_KEY"), models.WithStreamCallbacks(nil, onStream))
+	model := models.NewRemote(models.OpenAI, "gpt-4.1", os.Getenv("OPENAI_KEY"))
 	//model := models.NewAPIModel(models.Google, "gemini-2.5-flash", os.Getenv("GEMINI_KEY"), models.WithStreamCallbacks(nil, onStream))
-	encoder := encoders.NewFixed("Write 5 haikus about the topic")
-	parser := parsers.NewRaw()
-	pipeline := pipelines.NewOneShot(encoder, parser, nil, model)
 
 	fmt.Println("===== Stream =====")
-	// When we call the model, the callback will be called as the stream comes in.
-	// In this case, we are ignoring the final response. However, we really should not do this!
-	// In a production system, we should wipe any text that has been streamed and replace it with this final response,
-	// because we cannot trust that the stream actually happened.
-	_, usage, err := pipeline.Call(context.Background(), "Dogs")
+	// We will use the model directly instead of going through a pipeline.
+	// Pipelines are intended to be used for reliable data transformation, not realtime responses - this is due to their potential to retry on invalid messages etc.
+	// For this reason, it does not make sense for a pipeline to stream.
+	response, err := model.Respond(context.Background(), []jpf.Message{
+		{
+			Role:    jpf.SystemRole,
+			Content: "Write 5 haikus about the topic",
+		},
+		{
+			Role:    jpf.UserRole,
+			Content: "Dogs",
+		},
+	}, &printStreamer{})
 	fmt.Println()
 	fmt.Println()
 
 	fmt.Println("===== Tokens =====")
 	// The usage still works as normal, but it is only returned after the full response is complete.
-	fmt.Println(usage.InputTokens, usage.OutputTokens)
+	fmt.Println(response.Usage.InputTokens, response.Usage.OutputTokens)
 	if err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
 	fmt.Println()
 }
+
+type printStreamer struct{}
+
+func (*printStreamer) OnMessageBegin() {}
+func (*printStreamer) OnMessageText(text string) {
+	fmt.Print(text)
+}
+func (*printStreamer) OnMessageReset() {}

--- a/internal/utils/testing_utils.go
+++ b/internal/utils/testing_utils.go
@@ -38,7 +38,7 @@ type TestingModel struct {
 	NFails    int
 }
 
-func (t *TestingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (t *TestingModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	if t.NFails > 0 {
 		t.NFails--
 		return jpf.ModelResponse{}, errors.New("deliberate fail")
@@ -53,6 +53,10 @@ func (t *TestingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.Mod
 	}
 	resp, remaining := resps[0], resps[1:]
 	t.Responses[req] = remaining
+	if streamer != nil {
+		streamer.OnMessageBegin()
+		streamer.OnMessageText(resp)
+	}
 	return jpf.ModelResponse{
 		Message: jpf.Message{Role: jpf.AssistantRole, Content: resp},
 		Usage:   jpf.Usage{},
@@ -71,7 +75,7 @@ type SlowTestingModel struct {
 	Response jpf.ModelResponse
 }
 
-func (s *SlowTestingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (s *SlowTestingModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	// Use a timer that respects context cancellation
 	timer := time.NewTimer(s.Delay)
 	defer timer.Stop()
@@ -79,6 +83,10 @@ func (s *SlowTestingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf
 	select {
 	case <-timer.C:
 		// Delay completed, return response
+		if streamer != nil {
+			streamer.OnMessageBegin()
+			streamer.OnMessageText(s.Response.Message.Content)
+		}
 		return s.Response, nil
 	case <-ctx.Done():
 		// Context cancelled or timed out

--- a/models.go
+++ b/models.go
@@ -50,11 +50,16 @@ func (r ModelResponse) IncludingUsage(u Usage) ModelResponse {
 // Model defines an interface to an LLM.
 type Model interface {
 	// Responds to a set of input messages.
-	Respond(context.Context, []Message) (ModelResponse, error)
+	Respond(context.Context, []Message, ModelStreamer) (ModelResponse, error)
+}
+
+type ModelStreamer interface {
+	OnMessageBegin()
+	OnMessageText(text string)
+	OnMessageReset()
 }
 
 // Role is an enum specifying a role for a message.
-// It is not 1:1 with openai roles (i.e. there is a reasoning role here).
 type Role uint8
 
 const (

--- a/models/api.go
+++ b/models/api.go
@@ -32,7 +32,6 @@ const (
 
 type apiModelSettings struct {
 	url     string
-	stream  *streamCallbacks
 	headers map[string]string
 
 	temperature     *float64
@@ -44,11 +43,6 @@ type apiModelSettings struct {
 	maxOutput       *int
 
 	jsonSchema map[string]any
-}
-
-type streamCallbacks struct {
-	onBegin func()
-	onText  func(string)
 }
 
 type APIModelOpt func(*apiModelSettings)
@@ -77,9 +71,6 @@ func WithMaxOutput(n int) APIModelOpt {
 }
 func WithJSONSchema(schema map[string]any) APIModelOpt {
 	return func(kw *apiModelSettings) { kw.jsonSchema = schema }
-}
-func WithStreamCallbacks(onBegin func(), onText func(string)) APIModelOpt {
-	return func(kw *apiModelSettings) { kw.stream = &streamCallbacks{onBegin: onBegin, onText: onText} }
 }
 func WithHeader(key, value string) APIModelOpt {
 	return func(kw *apiModelSettings) {

--- a/models/api_gemini.go
+++ b/models/api_gemini.go
@@ -21,7 +21,7 @@ type apiGeminiModel struct {
 	settings apiModelSettings
 }
 
-func (m *apiGeminiModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (m *apiGeminiModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	err := m.validateNoUnusableArgs()
 	if err != nil {
 		return failedResponse(), utils.Wrap(err, "could not validate model setup")
@@ -30,7 +30,8 @@ func (m *apiGeminiModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.M
 	if err != nil {
 		return failedResponse(), utils.Wrap(err, "could not create request body")
 	}
-	req, err := m.createRequest(ctx, body)
+	isStreamed := streamer != nil
+	req, err := m.createRequest(ctx, body, isStreamed)
 	if err != nil {
 		return failedResponse(), utils.Wrap(err, "could not create request")
 	}
@@ -45,8 +46,8 @@ func (m *apiGeminiModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.M
 
 	var respTyped geminiStaticResponse
 	var rawRespBytes []byte
-	if m.settings.stream != nil {
-		respTyped, rawRespBytes, err = m.parseStreamResponse(ctx, resp.Body)
+	if streamer != nil {
+		respTyped, rawRespBytes, err = m.parseStreamResponse(ctx, resp.Body, streamer)
 	} else {
 		respTyped, rawRespBytes, err = m.parseStaticResponse(ctx, resp.Body)
 	}
@@ -87,7 +88,7 @@ func (m *apiGeminiModel) parseStaticResponse(ctx context.Context, respBody io.Re
 	return respTyped, respData, nil
 }
 
-func (m *apiGeminiModel) parseStreamResponse(ctx context.Context, respBody io.ReadCloser) (geminiStaticResponse, []byte, error) {
+func (m *apiGeminiModel) parseStreamResponse(ctx context.Context, respBody io.ReadCloser, streamer jpf.ModelStreamer) (geminiStaticResponse, []byte, error) {
 	go func() {
 		<-ctx.Done()
 		respBody.Close()
@@ -97,9 +98,7 @@ func (m *apiGeminiModel) parseStreamResponse(ctx context.Context, respBody io.Re
 	var fullText strings.Builder
 	var inputTokens, outputTokens int
 
-	if m.settings.stream != nil && m.settings.stream.onBegin != nil {
-		m.settings.stream.onBegin()
-	}
+	streamer.OnMessageBegin()
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -123,9 +122,7 @@ func (m *apiGeminiModel) parseStreamResponse(ctx context.Context, respBody io.Re
 			// concatenate all parts in this chunk
 			for _, p := range chunk.Candidates[0].Content.Parts {
 				fullText.WriteString(p.Text)
-				if m.settings.stream != nil && m.settings.stream.onText != nil {
-					m.settings.stream.onText(p.Text)
-				}
+				streamer.OnMessageText(p.Text)
 			}
 		}
 
@@ -176,9 +173,9 @@ func (m *apiGeminiModel) apiErrorResponse(resp *http.Response) (jpf.ModelRespons
 	return failedResponse(), fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respData))
 }
 
-func (m *apiGeminiModel) createRequest(ctx context.Context, body io.Reader) (*http.Request, error) {
+func (m *apiGeminiModel) createRequest(ctx context.Context, body io.Reader, isStreamed bool) (*http.Request, error) {
 	var modelUrl, extraStreamParam string
-	if m.settings.stream == nil {
+	if !isStreamed {
 		modelUrl = fmt.Sprintf("%s/%s:generateContent", m.settings.url, m.name)
 	} else {
 		modelUrl = fmt.Sprintf("%s/%s:streamGenerateContent", m.settings.url, m.name)

--- a/models/api_openai.go
+++ b/models/api_openai.go
@@ -21,8 +21,9 @@ type apiOpenAIModel struct {
 	settings apiModelSettings
 }
 
-func (m *apiOpenAIModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
-	body, err := m.createBodyData(msgs)
+func (m *apiOpenAIModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
+	isStreamed := streamer != nil
+	body, err := m.createBodyData(msgs, isStreamed)
 	if err != nil {
 		return failedResponse(), utils.Wrap(err, "could not create request body")
 	}
@@ -41,8 +42,8 @@ func (m *apiOpenAIModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.M
 
 	var respTyped openAIAPIStaticResponse
 	var rawRespBytes []byte
-	if m.settings.stream != nil {
-		respTyped, rawRespBytes, err = m.parseStreamResponse(ctx, resp.Body)
+	if streamer != nil {
+		respTyped, rawRespBytes, err = m.parseStreamResponse(ctx, resp.Body, streamer)
 	} else {
 		respTyped, rawRespBytes, err = m.parseStaticResponse(ctx, resp.Body)
 	}
@@ -88,7 +89,7 @@ func (m *apiOpenAIModel) parseStaticResponse(ctx context.Context, respBody io.Re
 	return respTyped, respData, nil
 }
 
-func (m *apiOpenAIModel) parseStreamResponse(ctx context.Context, respBody io.ReadCloser) (openAIAPIStaticResponse, []byte, error) {
+func (m *apiOpenAIModel) parseStreamResponse(ctx context.Context, respBody io.ReadCloser, streamer jpf.ModelStreamer) (openAIAPIStaticResponse, []byte, error) {
 	go func() {
 		<-ctx.Done()
 		respBody.Close()
@@ -97,9 +98,7 @@ func (m *apiOpenAIModel) parseStreamResponse(ctx context.Context, respBody io.Re
 	var fullContent strings.Builder
 	var inputTokens, outputTokens int
 
-	if m.settings.stream != nil && m.settings.stream.onBegin != nil {
-		m.settings.stream.onBegin()
-	}
+	streamer.OnMessageBegin()
 
 	for scanner.Scan() {
 		line := scanner.Bytes()
@@ -129,9 +128,7 @@ func (m *apiOpenAIModel) parseStreamResponse(ctx context.Context, respBody io.Re
 		if len(chunk.Choices) > 0 {
 			content := chunk.Choices[0].Delta.Content
 			fullContent.WriteString(content)
-			if m.settings.stream != nil && m.settings.stream.onText != nil {
-				m.settings.stream.onText(content)
-			}
+			streamer.OnMessageText(content)
 		}
 		if chunk.Usage.PromptTokens > 0 {
 			inputTokens = chunk.Usage.PromptTokens
@@ -186,12 +183,12 @@ func (m *apiOpenAIModel) createRequest(ctx context.Context, body io.Reader) (*ht
 	return req.WithContext(ctx), nil
 }
 
-func (m *apiOpenAIModel) createBodyData(msgs []jpf.Message) (io.Reader, error) {
+func (m *apiOpenAIModel) createBodyData(msgs []jpf.Message, isStreamed bool) (io.Reader, error) {
 	apiMessages, err := m.messages(msgs)
 	if err != nil {
 		return nil, utils.Wrap(err, "could not convert messages to OpenAI format")
 	}
-	body, err := m.body(apiMessages)
+	body, err := m.body(apiMessages, isStreamed)
 	if err != nil {
 		return nil, utils.Wrap(err, "could not create OpenAI format body")
 	}
@@ -264,7 +261,7 @@ func (m *apiOpenAIModel) messageContent(msg jpf.Message) (any, error) {
 	}
 }
 
-func (m *apiOpenAIModel) body(msgs []openAIAPIMessage) (map[string]any, error) {
+func (m *apiOpenAIModel) body(msgs []openAIAPIMessage, isStreamed bool) (map[string]any, error) {
 	bodyMap := map[string]any{
 		"model":    m.name,
 		"messages": msgs,
@@ -293,7 +290,7 @@ func (m *apiOpenAIModel) body(msgs []openAIAPIMessage) (map[string]any, error) {
 	if m.settings.jsonSchema != nil {
 		bodyMap["response_format"] = m.schema(m.settings.jsonSchema)
 	}
-	if m.settings.stream != nil {
+	if isStreamed {
 		bodyMap["stream"] = true
 		bodyMap["stream_options"] = map[string]any{"include_usage": true}
 	}

--- a/models/cached.go
+++ b/models/cached.go
@@ -34,17 +34,21 @@ type cachedModel struct {
 }
 
 // Respond implements Model.
-func (c *cachedModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (c *cachedModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	ok, final, err := c.cache.GetCachedResponse(ctx, c.salt, msgs)
 	if err != nil {
 		return jpf.ModelResponse{}, utils.Wrap(err, "failed to query cache")
 	}
 	if ok {
+		if streamer != nil {
+			streamer.OnMessageBegin()
+			streamer.OnMessageText(final.Content)
+		}
 		return jpf.ModelResponse{
 			Message: final,
 		}, nil
 	}
-	resp, err := c.model.Respond(ctx, msgs)
+	resp, err := c.model.Respond(ctx, msgs, streamer)
 	if err != nil {
 		return resp.OnlyUsage(), err
 	}

--- a/models/concurrentlimited.go
+++ b/models/concurrentlimited.go
@@ -22,11 +22,11 @@ type concurrentLimitedModel struct {
 	sem   *semaphore.Weighted
 }
 
-func (c *concurrentLimitedModel) Respond(ctx context.Context, messages []jpf.Message) (jpf.ModelResponse, error) {
+func (c *concurrentLimitedModel) Respond(ctx context.Context, messages []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	err := c.sem.Acquire(ctx, 1)
 	if err != nil {
 		return jpf.ModelResponse{}, err
 	}
 	defer c.sem.Release(1)
-	return c.model.Respond(ctx, messages)
+	return c.model.Respond(ctx, messages, streamer)
 }

--- a/models/logging.go
+++ b/models/logging.go
@@ -24,9 +24,9 @@ type loggingModel struct {
 }
 
 // Respond implements Model.
-func (l *loggingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (l *loggingModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	tStart := time.Now()
-	resp, err := l.model.Respond(ctx, msgs)
+	resp, err := l.model.Respond(ctx, msgs, streamer)
 	dur := time.Since(tStart)
 	lmp := jpf.ModelLoggingInfo{
 		Messages:             msgs,

--- a/models/map.go
+++ b/models/map.go
@@ -15,10 +15,10 @@ type mappingModel struct {
 	f     func(jpf.Message) jpf.Message
 }
 
-func (m *mappingModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (m *mappingModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	mappedMessages := make([]jpf.Message, len(msgs))
 	for i, msg := range msgs {
 		mappedMessages[i] = m.f(msg)
 	}
-	return m.model.Respond(ctx, mappedMessages)
+	return m.model.Respond(ctx, mappedMessages, streamer)
 }

--- a/models/model_test.go
+++ b/models/model_test.go
@@ -42,7 +42,7 @@ func TestCachedModel(t *testing.T) {
 	}}
 	model = Cache(model, newRamCache())
 	for i := range 5 {
-		resp1, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		resp1, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,7 +60,7 @@ func TestLoggingModel(t *testing.T) {
 	logger := NewMockLogger()
 	model = Log(model, logger)
 	for range 3 {
-		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -84,7 +84,7 @@ func TestRetryModel(t *testing.T) {
 		NFails: 3,
 	}
 	model = Retry(model, 3)
-	resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+	resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestRetryChainModel(t *testing.T) {
 				},
 			},
 		})
-		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +128,7 @@ func TestRetryChainModel(t *testing.T) {
 				},
 			},
 		})
-		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func TestRetryChainModel(t *testing.T) {
 				NFails:    1,
 			},
 		})
-		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err == nil {
 			t.Fatal("expected error but got none")
 		}
@@ -173,7 +173,7 @@ func TestRetryChainModel(t *testing.T) {
 				},
 			},
 		})
-		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -197,7 +197,7 @@ func TestTimeoutModel(t *testing.T) {
 		model := Timeout(slowModel, 50*time.Millisecond)
 
 		start := time.Now()
-		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		_, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		elapsed := time.Since(start)
 
 		// Should fail with context deadline exceeded
@@ -226,7 +226,7 @@ func TestTimeoutModel(t *testing.T) {
 		// Wrap with 100ms timeout (plenty of time)
 		model := Timeout(fastModel, 100*time.Millisecond)
 
-		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		resp, err := model.Respond(context.Background(), []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -252,7 +252,7 @@ func TestTimeoutModel(t *testing.T) {
 		defer cancel()
 
 		start := time.Now()
-		_, err := model.Respond(parentCtx, []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}})
+		_, err := model.Respond(parentCtx, []jpf.Message{{Role: jpf.SystemRole, Content: "hello"}}, nil)
 		elapsed := time.Since(start)
 
 		// Should fail with context deadline exceeded

--- a/models/ratelimited.go
+++ b/models/ratelimited.go
@@ -20,10 +20,10 @@ type rateLimitedModel struct {
 	model   jpf.Model
 }
 
-func (r *rateLimitedModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (r *rateLimitedModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	err := r.limiter.Wait(ctx)
 	if err != nil {
 		return jpf.ModelResponse{}, errors.Join(errors.New("failed to wait for rate limiter"), err)
 	}
-	return r.model.Respond(ctx, msgs)
+	return r.model.Respond(ctx, msgs, streamer)
 }

--- a/models/retry.go
+++ b/models/retry.go
@@ -35,17 +35,20 @@ type retryModel struct {
 	delay   time.Duration
 }
 
-func (m *retryModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (m *retryModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	var totalUsageSoFar jpf.Usage
 	var err error
 	for range m.retries + 1 {
 		var resp jpf.ModelResponse
-		resp, err = m.Model.Respond(ctx, msgs)
+		resp, err = m.Model.Respond(ctx, msgs, streamer)
 		resp = resp.IncludingUsage(totalUsageSoFar)
 		if err == nil {
 			return resp, nil
 		}
 		totalUsageSoFar = resp.Usage
+		if streamer != nil {
+			streamer.OnMessageReset()
+		}
 		time.Sleep(m.delay)
 	}
 	return jpf.ModelResponse{Usage: totalUsageSoFar}, utils.Wrap(err, "could not get model response after retrying %d times", m.retries)

--- a/models/retrychain.go
+++ b/models/retrychain.go
@@ -25,12 +25,12 @@ type retryChainModel struct {
 	models []jpf.Model
 }
 
-func (m *retryChainModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (m *retryChainModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	var errs []error
 	var totalUsageSoFar jpf.Usage
 
 	for i, model := range m.models {
-		resp, err := model.Respond(ctx, msgs)
+		resp, err := model.Respond(ctx, msgs, streamer)
 		resp = resp.IncludingUsage(totalUsageSoFar)
 
 		if err == nil {
@@ -39,6 +39,9 @@ func (m *retryChainModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.
 
 		errs = append(errs, fmt.Errorf("model %d failed: %w", i, err))
 		totalUsageSoFar = resp.Usage
+		if streamer != nil {
+			streamer.OnMessageReset()
+		}
 	}
 
 	return jpf.ModelResponse{Usage: totalUsageSoFar}, utils.Wrap(

--- a/models/timeout.go
+++ b/models/timeout.go
@@ -22,8 +22,8 @@ type timeoutModel struct {
 	timeout time.Duration
 }
 
-func (m *timeoutModel) Respond(ctx context.Context, msgs []jpf.Message) (jpf.ModelResponse, error) {
+func (m *timeoutModel) Respond(ctx context.Context, msgs []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
-	return m.Model.Respond(timeoutCtx, msgs)
+	return m.Model.Respond(timeoutCtx, msgs, streamer)
 }

--- a/models/usage_counting.go
+++ b/models/usage_counting.go
@@ -52,8 +52,8 @@ type usageCountingModel struct {
 	model   jpf.Model
 }
 
-func (c *usageCountingModel) Respond(ctx context.Context, messages []jpf.Message) (jpf.ModelResponse, error) {
-	resp, err := c.model.Respond(ctx, messages)
+func (c *usageCountingModel) Respond(ctx context.Context, messages []jpf.Message, streamer jpf.ModelStreamer) (jpf.ModelResponse, error) {
+	resp, err := c.model.Respond(ctx, messages, streamer)
 	c.counter.Add(resp.Usage)
 	return resp, err
 }

--- a/pipelines/feedback.go
+++ b/pipelines/feedback.go
@@ -50,7 +50,7 @@ func (mf *feedbackPipeline[T, U]) Call(ctx context.Context, t T) (U, jpf.Usage, 
 	totalUsage := jpf.Usage{}
 	var lastErr error
 	for range mf.maxRetries + 1 {
-		resp, err := mf.model.Respond(ctx, history)
+		resp, err := mf.model.Respond(ctx, history, nil)
 		totalUsage = totalUsage.Add(resp.Usage)
 		if err != nil {
 			return u, totalUsage, utils.Wrap(err, "failed to get model response")

--- a/pipelines/modelfallback.go
+++ b/pipelines/modelfallback.go
@@ -59,7 +59,7 @@ func (mf *fallbackPipeline[T, U]) callOne(ctx context.Context, t T, model jpf.Mo
 	if err != nil {
 		return zero, jpf.Usage{}, utils.Wrap(err, "failed to build input messages")
 	}
-	resp, err := model.Respond(ctx, msgs)
+	resp, err := model.Respond(ctx, msgs, nil)
 	if err != nil {
 		return zero, resp.Usage, utils.Wrap(err, "failed to get model response")
 	}

--- a/pipelines/oneshot.go
+++ b/pipelines/oneshot.go
@@ -36,7 +36,7 @@ func (mf *oneShotPipeline[T, U]) Call(ctx context.Context, t T) (U, jpf.Usage, e
 	if err != nil {
 		return zero, jpf.Usage{}, utils.Wrap(err, "failed to build input messages")
 	}
-	resp, err := mf.model.Respond(ctx, msgs)
+	resp, err := mf.model.Respond(ctx, msgs, nil)
 	if err != nil {
 		return zero, resp.Usage, utils.Wrap(err, "failed to get model response")
 	}


### PR DESCRIPTION
Streaming is to do with the individual call, not the model itself, so it should be in the Respond function
Fixes #78 